### PR TITLE
refactor: Remove axios dependency and use fetch instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.9",
-        "axios": "^0.21.1",
         "moment": "^2.29.1",
         "typeface-nunito": "^1.1.13",
         "vue": "^2.6.12"
@@ -3149,14 +3148,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "dependencies": {
-        "follow-redirects": "^1.10.0"
       }
     },
     "node_modules/babel-loader": {
@@ -6499,6 +6490,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
       "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -17892,14 +17884,6 @@
         }
       }
     },
-    "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "requires": {
-        "follow-redirects": "^1.10.0"
-      }
-    },
     "babel-loader": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
@@ -20480,7 +20464,8 @@
     "follow-redirects": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "homepage": "https://github.com/meyfa/ka-mensa-ui",
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "axios": "^0.21.1",
     "moment": "^2.29.1",
     "typeface-nunito": "^1.1.13",
     "vue": "^2.6.12"

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,3 @@
-import axios from 'axios'
-
 import { formatDate } from '~/util/date'
 
 // CLASS DEFINITION
@@ -23,17 +21,25 @@ class API {
     this.endpoint = endpoint
   }
 
+  async _fetchApi (path) {
+    const response = await fetch(this.endpoint + path)
+    if (!response.ok) {
+      throw new Error(response.statusText)
+    }
+    const body = await response.json()
+    if (!body.success) {
+      throw new Error(body.error)
+    }
+    return body.data
+  }
+
   /**
    * Fetch the set of available canteens.
    *
    * @returns {Promise} Resolves to an array of canteen objects.
    */
   async getCanteens () {
-    const { data } = await axios.get(this.endpoint + 'canteens')
-    if (!data.success) {
-      throw new Error(data.error)
-    }
-    return data.data
+    return await this._fetchApi('canteens')
   }
 
   /**
@@ -42,11 +48,7 @@ class API {
    * @returns {Promise} Resolves to an array of legend objects.
    */
   async getLegend () {
-    const { data } = await axios.get(this.endpoint + 'meta/legend')
-    if (!data.success) {
-      throw new Error(data.error)
-    }
-    return data.data
+    return await this._fetchApi('meta/legend')
   }
 
   /**
@@ -55,11 +57,7 @@ class API {
    * @returns {Promise} Resolves to an array of plan summary objects.
    */
   async getPlans () {
-    const { data } = await axios.get(this.endpoint + 'plans')
-    if (!data.success) {
-      throw new Error(data.error)
-    }
-    return data.data
+    return await this._fetchApi('plans')
   }
 
   /**
@@ -70,11 +68,7 @@ class API {
    */
   async getPlan (date) {
     const dateStr = formatDate(date)
-    const { data } = await axios.get(this.endpoint + 'plans/' + dateStr)
-    if (!data.success) {
-      throw new Error(data.error)
-    }
-    return data.data
+    return await this._fetchApi(`plans/${dateStr}`)
   }
 }
 


### PR DESCRIPTION
Surely we don't need a dependency just to perform a GET request,
when fetch is already well-established and works perfectly fine.