### PR TITLE
chore: Fix "name" not included in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ka-mensa-ui",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This was apparently added with a newer version of NPM, and is now
included in the package-lock.json for convenience.