### PR TITLE
refactor: Use Composition API for simple components

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -11,7 +11,7 @@
 
 <script>
 export default {
-  data () {
+  setup () {
     return {
       // PRIVACY_POLICY_URL is configurable (config.site.privacyPolicyUrl)
       // and defined via webpack

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -12,34 +12,33 @@
 </template>
 
 <script>
+import { onUnmounted, ref } from 'vue'
+
 import settingsPulse from '~/settings-pulse'
 
 export default {
   emits: ['settings-open'],
 
-  data () {
-    return {
-      unseenSettingsAvailable: false
+  setup (props, { emit }) {
+    const unseenSettingsAvailable = ref(!settingsPulse.isCurrent)
+
+    const updateSettingsPulse = () => {
+      unseenSettingsAvailable.value = !settingsPulse.isCurrent
     }
-  },
 
-  created () {
-    this.updateSettingsPulse()
-    settingsPulse.on('mark', this.updateSettingsPulse)
-  },
+    settingsPulse.on('mark', updateSettingsPulse)
+    onUnmounted(() => {
+      settingsPulse.removeListener('mark', updateSettingsPulse)
+    })
 
-  unmounted () {
-    settingsPulse.removeListener('mark', this.updateSettingsPulse)
-  },
-
-  methods: {
-    openSettings () {
-      this.$emit('settings-open')
+    const openSettings = () => {
+      emit('settings-open')
       settingsPulse.markCurrent()
-    },
+    }
 
-    updateSettingsPulse () {
-      this.unseenSettingsAvailable = !settingsPulse.isCurrent
+    return {
+      unseenSettingsAvailable,
+      openSettings
     }
   }
 }

--- a/src/components/DateHeader.vue
+++ b/src/components/DateHeader.vue
@@ -4,7 +4,7 @@
       <button type="button" class="dir-btn" @click="$emit('previous')">❮</button>
       <button class="date" @click="showDateSelection = true">
         <h2 class="date-title">{{ formatDate(date) }}</h2>
-        <div class="date-subtitle">{{ daysAgo(date) }}</div>
+        <div class="date-subtitle">{{ filterDaysAgo(date) }}</div>
       </button>
       <button type="button" class="dir-btn" @click="$emit('next')">❯</button>
     </div>
@@ -15,6 +15,8 @@
 </template>
 
 <script>
+import { onMounted, onUnmounted, ref } from 'vue'
+
 import DateSelectionDialog from '~/components/DateSelectionDialog'
 
 import { formatDate } from '../util/date'
@@ -34,27 +36,30 @@ export default {
 
   emits: ['next', 'previous', 'select'],
 
-  data () {
-    return {
-      showDateSelection: false,
-      sticky: false,
-      formatDate,
-      daysAgo: filterDaysAgo
+  setup () {
+    const container = ref(null)
+    const showDateSelection = ref(false)
+    const sticky = ref(false)
+
+    const recomputeSticky = () => {
+      sticky.value = container.value != null && container.value.getBoundingClientRect().top < 0
     }
-  },
 
-  mounted () {
-    this.recomputeSticky()
-    window.addEventListener('scroll', this.recomputeSticky)
-  },
+    onMounted(() => {
+      recomputeSticky()
+      window.addEventListener('scroll', recomputeSticky)
+    })
 
-  unmounted () {
-    window.removeEventListener('scroll', this.recomputeSticky)
-  },
+    onUnmounted(() => {
+      window.removeEventListener('scroll', recomputeSticky)
+    })
 
-  methods: {
-    recomputeSticky () {
-      this.sticky = this.$refs.container.getBoundingClientRect().top < 0
+    return {
+      container,
+      showDateSelection,
+      sticky,
+      formatDate,
+      filterDaysAgo
     }
   }
 }

--- a/src/components/DialogBase.vue
+++ b/src/components/DialogBase.vue
@@ -50,15 +50,10 @@ export default {
 
   emits: ['close'],
 
-  data () {
+  setup (props, { emit }) {
     return {
-      closeKeys: [ESCAPE_KEY, ENTER_KEY]
-    }
-  },
-
-  methods: {
-    close () {
-      this.$emit('close', false)
+      closeKeys: [ESCAPE_KEY, ENTER_KEY],
+      close: () => emit('close', false)
     }
   }
 }

--- a/src/components/MealItem.vue
+++ b/src/components/MealItem.vue
@@ -12,6 +12,8 @@
 </template>
 
 <script>
+import { computed } from 'vue'
+
 import { isVegetarian, isVegan } from '~/util/meals'
 
 export default {
@@ -28,17 +30,21 @@ export default {
 
   emits: ['click'],
 
-  computed: {
-    classifiersAndAdditives () {
-      return [...new Set([...this.meal.classifiers, ...this.meal.additives])]
-    },
+  setup (props) {
+    const classifiersAndAdditives = computed(() => [...new Set([
+      ...props.meal.classifiers,
+      ...props.meal.additives
+    ])])
 
-    mealClasses () {
-      return {
-        highlight: this.highlight,
-        vegetarian: isVegetarian(this.meal),
-        vegan: isVegan(this.meal)
-      }
+    const mealClasses = computed(() => ({
+      highlight: props.highlight,
+      vegetarian: isVegetarian(props.meal),
+      vegan: isVegan(props.meal)
+    }))
+
+    return {
+      classifiersAndAdditives,
+      mealClasses
     }
   }
 }

--- a/src/components/controls/SelectControl.vue
+++ b/src/components/controls/SelectControl.vue
@@ -31,24 +31,27 @@ export default {
 
   emits: ['update:selection'],
 
-  methods: {
-    isSelected (value) {
-      return this.selection.includes(value)
-    },
+  setup (props, { emit }) {
+    const isSelected = (value) => props.selection.includes(value)
 
-    setSelected (value, select) {
-      const currentlySelected = this.isSelected(value)
+    const setSelected = (value, select) => {
+      const currentlySelected = isSelected(value)
       // only allow toggling
       if (select === currentlySelected) {
         return
       }
-      const newSelection = [...this.selection]
+      const newSelection = [...props.selection]
       if (currentlySelected) {
         newSelection.splice(newSelection.indexOf(value), 1)
       } else {
         newSelection.push(value)
       }
-      this.$emit('update:selection', newSelection)
+      emit('update:selection', newSelection)
+    }
+
+    return {
+      isSelected,
+      setSelected
     }
   }
 }

--- a/src/components/functional/KeydownListener.vue
+++ b/src/components/functional/KeydownListener.vue
@@ -1,4 +1,6 @@
 <script>
+import { onMounted, onUnmounted } from 'vue'
+
 const EVENT_NAME = 'keydown'
 
 export default {
@@ -11,25 +13,24 @@ export default {
 
   emits: ['triggered'],
 
-  mounted () {
-    window.addEventListener(EVENT_NAME, this.handleEvent)
-  },
-
-  unmounted () {
-    window.removeEventListener(EVENT_NAME, this.handleEvent)
-  },
-
-  methods: {
-    handleEvent (event) {
-      if (!this.keys || !this.keys.length || this.keys.includes(event.keyCode)) {
+  setup (props, { emit }) {
+    const handleEvent = (event) => {
+      if (!props.keys || !props.keys.length || props.keys.includes(event.keyCode)) {
         event.preventDefault()
-        this.$emit('triggered', event)
+        emit('triggered', event)
       }
     }
-  },
 
-  render () {
-    return null
+    onMounted(() => {
+      window.addEventListener(EVENT_NAME, handleEvent)
+    })
+
+    onUnmounted(() => {
+      window.removeEventListener(EVENT_NAME, handleEvent)
+    })
+
+    // do not render anything
+    return () => null
   }
 }
 </script>

--- a/src/components/functional/PreventGlobalScrolling.vue
+++ b/src/components/functional/PreventGlobalScrolling.vue
@@ -1,6 +1,35 @@
 <script>
 // global counter for the number of prevent requests active (to allow for layered dialogs etc.)
+import { onMounted, onUnmounted } from 'vue'
+
 let preventCount = 0
+
+/**
+ * Increment the prevention counter.
+ */
+function increment () {
+  ++preventCount
+  // if this is the first instance, activate prevention
+  if (preventCount === 1) {
+    const previousBodyWidth = document.body.offsetWidth
+    document.documentElement.style.overflowY = 'hidden'
+    // adjust body padding to remove 'jumping' because of hidden scrollbar
+    const scrollbarWidth = document.body.offsetWidth - previousBodyWidth
+    document.body.style.paddingRight = scrollbarWidth + 'px'
+  }
+}
+
+/**
+ * Decrement the prevention counter. If it reaches 0, scrolling will be allowed again.
+ */
+function decrement () {
+  --preventCount
+  // if this was the last instance, deactivate prevention
+  if (preventCount === 0) {
+    document.documentElement.style.overflowY = ''
+    document.body.style.paddingRight = ''
+  }
+}
 
 export default {
   props: {
@@ -10,39 +39,12 @@ export default {
     }
   },
 
-  mounted () {
-    this.increment()
-  },
+  setup () {
+    onMounted(() => increment())
+    onUnmounted(() => decrement())
 
-  unmounted () {
-    this.decrement()
-  },
-
-  methods: {
-    increment () {
-      ++preventCount
-      // if this is the first instance, activate prevention
-      if (preventCount === 1) {
-        const previousBodyWidth = document.body.offsetWidth
-        document.documentElement.style.overflowY = 'hidden'
-        // adjust body padding to remove 'jumping' because of hidden scrollbar
-        const scrollbarWidth = document.body.offsetWidth - previousBodyWidth
-        document.body.style.paddingRight = scrollbarWidth + 'px'
-      }
-    },
-
-    decrement () {
-      --preventCount
-      // if this was the last instance, deactivate prevention
-      if (preventCount === 0) {
-        document.documentElement.style.overflowY = ''
-        document.body.style.paddingRight = ''
-      }
-    }
-  },
-
-  render () {
-    return null
+    // do not render anything
+    return () => null
   }
 }
 </script>

--- a/src/components/settings/AppearanceSettings.vue
+++ b/src/components/settings/AppearanceSettings.vue
@@ -17,43 +17,46 @@
 </template>
 
 <script>
-import { defineComponent } from 'vue'
+import { ref, watch } from 'vue'
+
 import settings from '~/settings'
 
 import ChoiceControl from '~/components/controls/ChoiceControl'
 import CheckControl from '~/components/controls/CheckControl'
 
-export default defineComponent({
+export default {
   components: {
     ChoiceControl,
     CheckControl
   },
 
-  data () {
+  setup () {
+    const theme = ref(settings.theme)
+    const hideEmptyLines = ref(settings.hideEmptyLines)
+    const enableHighlights = ref(settings.enableHighlights)
+
+    watch(theme, (value) => {
+      settings.theme = value
+    })
+
+    watch(hideEmptyLines, (value) => {
+      settings.hideEmptyLines = value
+    })
+
+    watch(enableHighlights, (value) => {
+      settings.enableHighlights = value
+    })
+
     return {
       themes: {
         light: 'hell',
         dark: 'dunkel',
         auto: 'an Systemeinstellungen anpassen'
       },
-      theme: settings.theme,
-      hideEmptyLines: settings.hideEmptyLines,
-      enableHighlights: settings.enableHighlights
-    }
-  },
-
-  watch: {
-    theme (to) {
-      settings.theme = to
-    },
-
-    hideEmptyLines (to) {
-      settings.hideEmptyLines = to
-    },
-
-    enableHighlights (to) {
-      settings.enableHighlights = to
+      theme,
+      hideEmptyLines,
+      enableHighlights
     }
   }
-})
+}
 </script>

--- a/src/components/settings/FilterSettings.vue
+++ b/src/components/settings/FilterSettings.vue
@@ -7,6 +7,8 @@
 </template>
 
 <script>
+import { ref, watch } from 'vue'
+
 import settings from '~/settings'
 
 import ChoiceControl from '~/components/controls/ChoiceControl'
@@ -16,19 +18,19 @@ export default {
     ChoiceControl
   },
 
-  data () {
+  setup () {
+    const eatingHabits = ref(settings.eatingHabits)
+
+    watch(eatingHabits, (value) => {
+      settings.eatingHabits = value
+    })
+
     return {
       eatingHabitsOptions: {
         all: 'alles',
         vegetarian: 'vegetarisch/vegan'
       },
-      eatingHabits: settings.eatingHabits
-    }
-  },
-
-  watch: {
-    eatingHabits (to) {
-      settings.eatingHabits = to
+      eatingHabits
     }
   }
 }


### PR DESCRIPTION
This makes use of Vue 3's composition API via the setup() method for
a subset of all components (those that could be converted easily).
The remaining ones will follow.