### PR TITLE
fix: Mount app to body to avoid duplicate id

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -5,6 +5,5 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>
-    <div id="app"></div>
   </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import 'moment/locale/de'
 
 moment.locale('de')
 
-createApp(App as any).mount('#app')
+createApp(App as any).mount('body')
 
 if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {


### PR DESCRIPTION
Vue 3 changed how components are mounted. They do not replace the
element they are mounted to any more, but are appended as children.
Hence, we append the App component directly to body to avoid duplication
of id #app.