### PR TITLE
fix: Add explicit space between meal item classifiers

### DIFF
--- a/src/components/MealItem.vue
+++ b/src/components/MealItem.vue
@@ -2,7 +2,7 @@
   <button type="button" class="meal" :class="mealClasses" @click="$emit('click')">
     <div class="meal-classifiers">
       <span v-for="cls in classifiersAndAdditives" :key="cls">
-        {{ cls }}
+        {{ cls }}{{ ' ' }}
       </span>
     </div>
 


### PR DESCRIPTION
The space gets removed by the build process otherwise.