### PR TITLE
style: Remove types from JSDoc

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,3 +23,8 @@ rules:
   vue/singleline-html-element-content-newline: 0
   vue/html-closing-bracket-newline: 0
   vue/component-name-in-template-casing: [2, PascalCase]
+  # require JSDoc on every standard location, and also on classes, interfaces and enums
+  jsdoc/require-jsdoc: [ 'error', { contexts: [ 'ClassDeclaration', 'TSInterfaceDeclaration', 'TSEnumDeclaration' ] } ]
+  jsdoc/require-param-type: off
+  jsdoc/require-returns-type: off
+  jsdoc/no-types: error

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,7 +11,7 @@ class API {
   /**
    * Create a new API client for the given endpoint URL.
    *
-   * @param {string} endpoint The endpoint URL to use.
+   * @param endpoint The endpoint URL to use.
    */
   constructor (endpoint: string) {
     if (typeof endpoint !== 'string' || endpoint.length <= 0) {
@@ -38,7 +38,7 @@ class API {
   /**
    * Fetch the set of available canteens.
    *
-   * @returns {Promise} Resolves to an array of canteen objects.
+   * @returns Resolves to an array of canteen objects.
    */
   async getCanteens (): Promise<any> {
     return await this._fetchApi('canteens')
@@ -47,7 +47,7 @@ class API {
   /**
    * Fetch the set of legend entries containing 'short' and 'label' strings.
    *
-   * @returns {Promise} Resolves to an array of legend objects.
+   * @returns Resolves to an array of legend objects.
    */
   async getLegend (): Promise<any> {
     return await this._fetchApi('meta/legend')
@@ -56,7 +56,7 @@ class API {
   /**
    * Fetch the set of plan summaries.
    *
-   * @returns {Promise} Resolves to an array of plan summary objects.
+   * @returns Resolves to an array of plan summary objects.
    */
   async getPlans (): Promise<any> {
     return await this._fetchApi('plans')
@@ -65,8 +65,8 @@ class API {
   /**
    * Fetch the set of plans for the given date.
    *
-   * @param {object} date A date object.
-   * @returns {Promise} Resolves to an array of plans.
+   * @param date A date object.
+   * @returns Resolves to an array of plans.
    */
   async getPlan (date: DateSpec): Promise<any> {
     const dateStr = formatDate(date)

--- a/src/filters/days-ago.ts
+++ b/src/filters/days-ago.ts
@@ -5,8 +5,8 @@ import { getCurrentDate } from '../util/date'
  * Given a date specification, this returns a string representing that date relative
  * to the current date.
  *
- * @param {object} value The date value.
- * @returns {string} The formatted relative date.
+ * @param value The date value.
+ * @returns The formatted relative date.
  */
 export function filterDaysAgo (value: any): string {
   if (value != null && value !== '') {

--- a/src/settings-pulse.ts
+++ b/src/settings-pulse.ts
@@ -16,7 +16,7 @@ const VERSION = 2
  */
 class SettingsPulse extends EventEmitter {
   /**
-   * @returns {boolean} Whether the user has seen the most recent settings.
+   * @returns Whether the user has seen the most recent settings.
    */
   get isCurrent (): boolean {
     const value = localStorage.getItem(LOCALSTORAGE_KEY)
@@ -25,8 +25,6 @@ class SettingsPulse extends EventEmitter {
 
   /**
    * Mark the current settings version as having been seen by the user.
-   *
-   * @returns {void}
    */
   markCurrent (): void {
     localStorage.setItem(LOCALSTORAGE_KEY, VERSION.toString())

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,7 +9,7 @@ const LOCALSTORAGE_KEY = 'mensa-ui.settings'
 /**
  * Read the settings data from persistent storage.
  *
- * @returns {object} The data.
+ * @returns The data.
  */
 function readLocalStorage (): Record<string, any> | undefined {
   const json = localStorage.getItem(LOCALSTORAGE_KEY)
@@ -25,8 +25,7 @@ function readLocalStorage (): Record<string, any> | undefined {
 /**
  * Write settings data to persistent storage.
  *
- * @param {object} data The data.
- * @returns {void}
+ * @param data The data.
  */
 function writeLocalStorage (data: Record<string, any>): void {
   const json = JSON.stringify(data)
@@ -61,7 +60,7 @@ class Settings extends EventEmitter {
    * Re-load settings data from persistent storage.
    *
    * @access private
-   * @returns {boolean} Success value.
+   * @returns Success value.
    */
   load (): boolean {
     const stored = readLocalStorage()
@@ -77,7 +76,6 @@ class Settings extends EventEmitter {
    * Write settings data to persistent storage.
    *
    * @access private
-   * @returns {void}
    */
   save (): void {
     writeLocalStorage(this._data)
@@ -85,7 +83,7 @@ class Settings extends EventEmitter {
   }
 
   /**
-   * @returns {string} The page theme ('light', 'dark' or 'auto').
+   * @returns The page theme ('light', 'dark' or 'auto').
    */
   get theme (): string {
     return this._data.theme ?? 'auto'
@@ -97,7 +95,7 @@ class Settings extends EventEmitter {
   }
 
   /**
-   * @returns {string[]} The canteens selected for display.
+   * @returns The canteens selected for display.
    */
   get canteens (): string[] {
     return this._data.canteens != null
@@ -112,7 +110,7 @@ class Settings extends EventEmitter {
   }
 
   /**
-   * @returns {boolean} Whether canteen lines with no meals should be hidden.
+   * @returns Whether canteen lines with no meals should be hidden.
    */
   get hideEmptyLines (): boolean {
     return typeof this._data.hideEmptyLines === 'boolean'
@@ -126,7 +124,7 @@ class Settings extends EventEmitter {
   }
 
   /**
-   * @returns {string} The eating habits ('all' or 'vegetarian').
+   * @returns The eating habits ('all' or 'vegetarian').
    */
   get eatingHabits (): string {
     return this._data.eatingHabits ?? 'all'
@@ -138,7 +136,7 @@ class Settings extends EventEmitter {
   }
 
   /**
-   * @returns {boolean} Whether to highlight vegetarian + vegan menus.
+   * @returns Whether to highlight vegetarian + vegan menus.
    */
   get enableHighlights (): boolean {
     return typeof this._data.enableHighlights === 'boolean'

--- a/src/util/date.ts
+++ b/src/util/date.ts
@@ -7,16 +7,16 @@ const DATE_FORMAT = 'YYYY-MM-DD'
 // HELPER METHODS
 
 /**
- * @param {object} mnt The moment to convert to a date object.
- * @returns {object} The conversion result.
+ * @param mnt The moment to convert to a date object.
+ * @returns The conversion result.
  */
 function fromMoment (mnt: Moment): DateSpec {
   return { year: mnt.year(), month: mnt.month(), day: mnt.date() }
 }
 
 /**
- * @param {object} date The date object to convert to a moment.
- * @returns {object} The moment.
+ * @param date The date object to convert to a moment.
+ * @returns The moment.
  */
 function toMoment (date: DateSpec): Moment {
   // moment supports parse via object with compatible schema
@@ -25,6 +25,9 @@ function toMoment (date: DateSpec): Moment {
 
 // EXPORTS
 
+/**
+ * Standard date specification used in this application.
+ */
 export interface DateSpec {
   year: number
   month: number
@@ -34,7 +37,7 @@ export interface DateSpec {
 /**
  * Get a date object for the current date.
  *
- * @returns {object} A date object containing year, month, day properties.
+ * @returns A date object containing year, month, day properties.
  */
 export function getCurrentDate (): DateSpec {
   return fromMoment(moment())
@@ -43,8 +46,8 @@ export function getCurrentDate (): DateSpec {
 /**
  * Format the date object YYYY-MM-DD.
  *
- * @param {object} date The date.
- * @returns {string} The formatted string.
+ * @param date The date.
+ * @returns The formatted string.
  */
 export function formatDate (date: DateSpec): string {
   return toMoment(date).format(DATE_FORMAT)
@@ -53,8 +56,8 @@ export function formatDate (date: DateSpec): string {
 /**
  * Check whether the given date is a weekday (Mo - Fr).
  *
- * @param {object} date The date.
- * @returns {boolean} Whether the date is a weekday.
+ * @param date The date.
+ * @returns Whether the date is a weekday.
  */
 export function isWeekday (date: DateSpec): boolean {
   return toMoment(date).isoWeekday() <= 5
@@ -63,8 +66,8 @@ export function isWeekday (date: DateSpec): boolean {
 /**
  * Get the first weekday after the given date.
  *
- * @param {object} date The date.
- * @returns {object} The date of the next weekday.
+ * @param date The date.
+ * @returns The date of the next weekday.
  */
 export function getNextWeekday (date: DateSpec): DateSpec {
   // get moment for next day
@@ -80,8 +83,8 @@ export function getNextWeekday (date: DateSpec): DateSpec {
 /**
  * Get the first weekday before the given date.
  *
- * @param {object} date The date.
- * @returns {object} The date of the previous weekday.
+ * @param date The date.
+ * @returns The date of the previous weekday.
  */
 export function getPreviousWeekday (date: DateSpec): DateSpec {
   // get moment for next day

--- a/src/util/meals.ts
+++ b/src/util/meals.ts
@@ -11,8 +11,8 @@ const CLASSIFIER_VEGAN = 'VG'
  *
  * This returns false for vegan meals.
  *
- * @param {object} meal The meal.
- * @returns {boolean} Whether the meal is vegetarian.
+ * @param meal The meal.
+ * @returns Whether the meal is vegetarian.
  */
 export function isVegetarian (meal: any): boolean {
   return meal.classifiers.includes(CLASSIFIER_VEGETARIAN)
@@ -21,8 +21,8 @@ export function isVegetarian (meal: any): boolean {
 /**
  * Determine whether the given meal is strictly vegan.
  *
- * @param {object} meal The meal.
- * @returns {boolean} Whether the meal is vegan.
+ * @param meal The meal.
+ * @returns Whether the meal is vegan.
  */
 export function isVegan (meal: any): boolean {
   return meal.classifiers.includes(CLASSIFIER_VEGAN)
@@ -31,8 +31,8 @@ export function isVegan (meal: any): boolean {
 /**
  * Determine whether the given meal is an informational entry, i.e. not a meal.
  *
- * @param {object} meal The meal.
- * @returns {boolean} Whether the meal is informational.
+ * @param meal The meal.
+ * @returns Whether the meal is informational.
  */
 export function isInfo (meal: any): boolean {
   return meal.classifiers.length === 0 && meal.additives.length === 0


### PR DESCRIPTION
Type information is sufficiently available through TypeScript and need
not be repeated in the docs.