### PR TITLE
refactor: Stop using babel-plugin-root-import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@typescript-eslint/eslint-plugin": "^4.29.1",
         "@vue/compiler-sfc": "^3.2.2",
         "babel-loader": "^8.2.2",
-        "babel-plugin-root-import": "^6.6.0",
         "clean-webpack-plugin": "^3.0.0",
         "cross-env": "^7.0.3",
         "css-loader": "^6.2.0",
@@ -3473,15 +3472,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/babel-plugin-root-import": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-root-import/-/babel-plugin-root-import-6.6.0.tgz",
-      "integrity": "sha512-SPzVOHd7nDh5loZwZBxtX/oOu1MXeKjTkz+1VnnzLWC0dk8sJIGC2IDQ2uWIBjE5mUtXlQ35MTHSqN0Xn7qHrg==",
-      "dev": true,
-      "dependencies": {
-        "slash": "^3.0.0"
       }
     },
     "node_modules/bail": {
@@ -18686,15 +18676,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.2.2"
-      }
-    },
-    "babel-plugin-root-import": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-root-import/-/babel-plugin-root-import-6.6.0.tgz",
-      "integrity": "sha512-SPzVOHd7nDh5loZwZBxtX/oOu1MXeKjTkz+1VnnzLWC0dk8sJIGC2IDQ2uWIBjE5mUtXlQ35MTHSqN0Xn7qHrg==",
-      "dev": true,
-      "requires": {
-        "slash": "^3.0.0"
       }
     },
     "bail": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@typescript-eslint/eslint-plugin": "^4.29.1",
     "@vue/compiler-sfc": "^3.2.2",
     "babel-loader": "^8.2.2",
-    "babel-plugin-root-import": "^6.6.0",
     "clean-webpack-plugin": "^3.0.0",
     "cross-env": "^7.0.3",
     "css-loader": "^6.2.0",

--- a/src/.babelrc.js
+++ b/src/.babelrc.js
@@ -1,10 +1,5 @@
-const path = require('path')
-
 const presets = ['@babel/env']
 const plugins = [
-  ['babel-plugin-root-import', {
-    rootPathSuffix: path.join(__dirname)
-  }],
   ['@babel/transform-runtime']
 ]
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,14 +16,14 @@ import { onMounted, onUnmounted, ref } from 'vue'
 
 import 'typeface-nunito'
 
-import settings from '~/settings'
-import { getCurrentDate, isWeekday, getPreviousWeekday, getNextWeekday } from '~/util/date'
+import settings from './settings'
+import { getCurrentDate, isWeekday, getPreviousWeekday, getNextWeekday } from './util/date'
 
-import AppHeader from '~/components/AppHeader'
-import AppFooter from '~/components/AppFooter'
-import DateHeader from '~/components/DateHeader'
-import PlansView from '~/components/PlansView'
-import SettingsDialog from '~/components/SettingsDialog'
+import AppHeader from './components/AppHeader'
+import AppFooter from './components/AppFooter'
+import DateHeader from './components/DateHeader'
+import PlansView from './components/PlansView'
+import SettingsDialog from './components/SettingsDialog'
 
 const prefersDarkScheme = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null
 

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -13,7 +13,7 @@
 <script>
 import { onMounted, onUnmounted, ref } from 'vue'
 
-import settingsPulse from '~/settings-pulse'
+import settingsPulse from '../settings-pulse'
 
 export default {
   emits: ['settings-open'],

--- a/src/components/CanteenLines.vue
+++ b/src/components/CanteenLines.vue
@@ -24,11 +24,12 @@
 </template>
 
 <script>
-import settings from '~/settings'
-import { isVegetarian, isVegan, isInfo } from '~/util/meals'
-
-import MealItem from '~/components/MealItem'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
+
+import settings from '../settings'
+import { isVegetarian, isVegan, isInfo } from '../util/meals'
+
+import MealItem from './MealItem'
 
 export default {
   components: {

--- a/src/components/DateHeader.vue
+++ b/src/components/DateHeader.vue
@@ -17,7 +17,7 @@
 <script>
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 
-import DateSelectionDialog from '~/components/DateSelectionDialog'
+import DateSelectionDialog from './DateSelectionDialog'
 
 import { formatDate } from '../util/date'
 import { filterDaysAgo } from '../filters/days-ago'

--- a/src/components/DateSelectionDialog.vue
+++ b/src/components/DateSelectionDialog.vue
@@ -9,10 +9,10 @@
 <script>
 import { computed, onMounted, ref } from 'vue'
 
-import api from '~/api'
+import api from '../api'
 
-import DialogBase from '~/components/DialogBase'
-import CalendarView from '~/components/CalendarView'
+import DialogBase from './DialogBase'
+import CalendarView from './CalendarView'
 
 export default {
   components: {

--- a/src/components/DialogBase.vue
+++ b/src/components/DialogBase.vue
@@ -18,8 +18,8 @@
 </template>
 
 <script>
-import PreventGlobalScrolling from '~/components/functional/PreventGlobalScrolling'
-import KeydownListener from '~/components/functional/KeydownListener'
+import PreventGlobalScrolling from './functional/PreventGlobalScrolling'
+import KeydownListener from './functional/KeydownListener'
 
 const ESCAPE_KEY = 27
 const ENTER_KEY = 13

--- a/src/components/MealDetailsDialog.vue
+++ b/src/components/MealDetailsDialog.vue
@@ -19,9 +19,9 @@
 <script>
 import { computed, ref, watchEffect } from 'vue'
 
-import api from '~/api'
+import api from '../api'
 
-import DialogBase from '~/components/DialogBase'
+import DialogBase from './DialogBase'
 
 export default {
   components: {

--- a/src/components/MealItem.vue
+++ b/src/components/MealItem.vue
@@ -14,7 +14,7 @@
 <script>
 import { computed } from 'vue'
 
-import { isVegetarian, isVegan } from '~/util/meals'
+import { isVegetarian, isVegan } from '../util/meals'
 
 export default {
   props: {

--- a/src/components/PlansView.vue
+++ b/src/components/PlansView.vue
@@ -16,11 +16,11 @@
 <script>
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
-import api from '~/api'
-import settings from '~/settings'
+import api from '../api'
+import settings from '../settings'
 
-import CanteenLines from '~/components/CanteenLines'
-import MealDetailsDialog from '~/components/MealDetailsDialog'
+import CanteenLines from './CanteenLines'
+import MealDetailsDialog from './MealDetailsDialog'
 
 export default {
   components: {

--- a/src/components/SettingsDialog.vue
+++ b/src/components/SettingsDialog.vue
@@ -21,11 +21,11 @@
 </template>
 
 <script>
-import DialogBase from '~/components/DialogBase'
+import DialogBase from './DialogBase'
 
-import CanteensSettings from '~/components/settings/CanteensSettings'
-import FilterSettings from '~/components/settings/FilterSettings'
-import AppearanceSettings from '~/components/settings/AppearanceSettings'
+import CanteensSettings from './settings/CanteensSettings'
+import FilterSettings from './settings/FilterSettings'
+import AppearanceSettings from './settings/AppearanceSettings'
 
 export default {
   components: {

--- a/src/components/controls/SelectControl.vue
+++ b/src/components/controls/SelectControl.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import CheckControl from '~/components/controls/CheckControl'
+import CheckControl from './CheckControl'
 
 export default {
   components: {

--- a/src/components/settings/AppearanceSettings.vue
+++ b/src/components/settings/AppearanceSettings.vue
@@ -18,10 +18,10 @@
 <script>
 import { ref, watch } from 'vue'
 
-import settings from '~/settings'
+import settings from '../../settings'
 
-import ChoiceControl from '~/components/controls/ChoiceControl'
-import CheckControl from '~/components/controls/CheckControl'
+import ChoiceControl from '../controls/ChoiceControl'
+import CheckControl from '../controls/CheckControl'
 
 export default {
   components: {

--- a/src/components/settings/CanteensSettings.vue
+++ b/src/components/settings/CanteensSettings.vue
@@ -11,10 +11,10 @@
 <script>
 import { computed, onMounted, ref, watch } from 'vue'
 
-import settings from '~/settings'
-import api from '~/api'
+import settings from '../../settings'
+import api from '../../api'
 
-import SelectControl from '~/components/controls/SelectControl'
+import SelectControl from '../controls/SelectControl'
 
 export default {
   components: {

--- a/src/components/settings/FilterSettings.vue
+++ b/src/components/settings/FilterSettings.vue
@@ -9,9 +9,9 @@
 <script>
 import { ref, watch } from 'vue'
 
-import settings from '~/settings'
+import settings from '../../settings'
 
-import ChoiceControl from '~/components/controls/ChoiceControl'
+import ChoiceControl from '../controls/ChoiceControl'
 
 export default {
   components: {


### PR DESCRIPTION
Tooling and IDE support is a lot worse with transformed import paths,
and the gains are minimal, so the plugin is removed.