### PR TITLE
fix: Initially the current day is selected, even if not a weekday

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -46,7 +46,7 @@ export default defineComponent({
     }
 
     const showSettings = ref(false)
-    const date = ref(getCurrentDate())
+    const date = ref(currentDate)
 
     const updateSettings = () => {
       let darkTheme = settings.theme === 'dark'


### PR DESCRIPTION
When loading the page, if the current day is not between Monday-Friday
(inclusive), it now correctly shows the upcoming Monday.