### PR TITLE
feat: Setup deployment via Docker

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,10 +11,6 @@ overrides:
       extraFileExtensions: ['.vue']
       project: './tsconfig.json'
 
-globals:
-  API_ENDPOINT: readonly
-  PRIVACY_POLICY_URL: readonly
-
 rules:
   vue/html-indent: ['error', 2, { attribute: 2, baseIndent: 1, closeBracket: 0, alignAttributesVertically: false }]
   vue/max-attributes-per-line: 0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: CI to Docker Hub
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags:  ${{ secrets.DOCKER_HUB_USERNAME }}/ka-mensa-ui:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# build
+FROM node:lts-alpine as build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . ./
+RUN npm run build
+
+# production
+FROM nginx:stable-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY --from=build /app/docker-nginx-template.conf /
+ENV API_ENDPOINT=""
+ENV PRIVACY_POLICY_URL=""
+CMD ["/bin/sh" , "-c" , "envsubst < /docker-nginx-template.conf > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"]
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -29,16 +29,42 @@ The entire project is written in JavaScript+TypeScript and is composed as follow
 
 Make sure to have a `ka-mensa-api` server running and publicly accessible.
 If on another domain, you have to configure your server to set CORS headers.
+Now you've got two choices: You can clone this repository via Git, build
+manually and use your own web server; or you can use a pre-built Docker image
+based on Nginx.
 
-Then, clone this repository somewhere. Run `npm install` (Node and npm must be
-installed on your system!).
+### The Git Way
+
+Clone this repository somewhere. Make sure Node and npm are installed on your
+system. Then run `npm install`.
 
 Open up `config.js` and configure to your liking. Pay special attention to
 setting the API endpoint so that requests can be sent to your API server.
 
 If you now run `npm run build`, the frontend will be compiled with the
 configured options and the result placed in the `dist` directory. Throw it on a
-webserver and load it up to see a fancy canteen plan UI.
+webserver and you're good to go!
+
+### The Docker Way
+
+To start a webserver linked to your API instance, simply run the Docker
+container and pass in config options via environment variables:
+
+```sh
+docker run \
+        --name mensa-ui \
+        -p <host-port>:8080 \
+        -e API_ENDPOINT=https://my-ka-mensa-api.example.com \
+        -e PRIVACY_POLICY_URL=https://example.com/privacy \
+        -d meyfa/ka-mensa-ui
+```
+
+It's as simple as that! Note that specifying `API_ENDPOINT` is mandatory. The
+environment variables MUST NOT contain single quotes or backslashes unless
+escaped with a backslash (i.e. `\'` and `\\`, respectively).
+
+(Internally, there is some magic that injects these environment variables into
+the nginx config, which then injects them into the page.)
 
 
 ## Development

--- a/docker-nginx-template.conf
+++ b/docker-nginx-template.conf
@@ -1,0 +1,11 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        sub_filter <head>
+            '<head><script>window.env = { API_ENDPOINT: "${API_ENDPOINT}", PRIVACY_POLICY_URL: "${PRIVACY_POLICY_URL}" }</script>';
+        root   /usr/share/nginx/html;
+        index  index.html;
+    }
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,4 @@
+import env from './env'
 import { DateSpec } from './types/date-spec'
 import { formatDate } from './util/date'
 import { CanteenPlan } from './types/canteen-plan'
@@ -77,9 +78,6 @@ class API {
 
 // EXPORT
 
-// API_ENDPOINT is configurable (config.api.endpoint) and defined via webpack
-declare const API_ENDPOINT: string
-
 /**
  * Ensure the given parameter is a trimmed string ending with a slash.
  *
@@ -97,4 +95,4 @@ function sanitizeUrl (url: any): string {
   return trimmed.endsWith('/') ? trimmed : `${trimmed}/`
 }
 
-export default new API(sanitizeUrl(API_ENDPOINT))
+export default new API(sanitizeUrl(env.API_ENDPOINT))

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -11,14 +11,12 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-
-// PRIVACY_POLICY_URL is configurable (config.site.privacyPolicyUrl) and defined via webpack
-declare const PRIVACY_POLICY_URL: string
+import env from '../env'
 
 export default defineComponent({
   setup () {
     return {
-      privacyPolicyUrl: PRIVACY_POLICY_URL,
+      privacyPolicyUrl: env.PRIVACY_POLICY_URL,
       url: 'https://github.com/meyfa/ka-mensa-ui'
     }
   }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,52 @@
+/**
+ * This file facilitates access to config options, which may be defined via the config.js during build time
+ * but may also be overridden at run-time via Docker environment variables and injected by envsubst inside
+ * the nginx config.
+ */
+
+/**
+ * This interface contains all available options.
+ */
+export interface Env {
+  API_ENDPOINT: string
+  PRIVACY_POLICY_URL: string
+}
+
+// webpack definitions
+declare const API_ENDPOINT: string
+declare const PRIVACY_POLICY_URL: string
+
+// environment variables on window object
+declare global {
+  /**
+   * Extension of window to allow access to env.
+   */
+  interface Window {
+    env?: Partial<Env>
+  }
+}
+
+/**
+ * Given a set of env values prioritized by order, get the first valid one.
+ *
+ * @param key The option key.
+ * @param fallback The value injected via Webpack.
+ * @returns The chosen option.
+ */
+function resolve<K extends keyof Env> (key: K, fallback: string): string {
+  const valueOnWindow = window.env != null ? window.env[key] : undefined
+  if (valueOnWindow != null && valueOnWindow !== '') {
+    return valueOnWindow
+  }
+  return fallback
+}
+
+const computedEnv: Env = {
+  API_ENDPOINT: resolve('API_ENDPOINT', API_ENDPOINT),
+  PRIVACY_POLICY_URL: resolve('PRIVACY_POLICY_URL', PRIVACY_POLICY_URL)
+}
+
+/**
+ * The fully resolved options for this build.
+ */
+export default computedEnv


### PR DESCRIPTION
Adds a Dockerfile. Nginx is used as the base image, and envsubst lets us
inject the Docker environment variables into Nginx's config, which can
then inject them into the page. This means that it is now possible to
either run the build process manually (which will use the settings from
config.js) or use the Docker image (which will use environment
variables, insofar as they are defined by the user).