### PR TITLE
chore(graa): Extend js-app config

### DIFF
--- a/.graa.yml
+++ b/.graa.yml
@@ -1,1 +1,1 @@
-extends: 'config:base'
+extends: 'config:js-app'


### PR DESCRIPTION
This is needed due to added renovate auto-configure in the GRAA bundled configs.