### PR TITLE
fix: Set manifestFilename to 'manifest.json'

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [
     vue(),
     VitePWA({
+      manifestFilename: 'manifest.json',
       registerType: 'autoUpdate',
       includeAssets: ['favicon.ico', 'robots.txt', 'apple-touch-icon.png'],
       manifest: {


### PR DESCRIPTION
This means nginx will now serve it with the MIME type of JSON, which was
previously not the case and could lead to errors.