### PR TITLE
fix: Set manifest short_name explicitly

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       includeAssets: ['favicon.ico', 'robots.txt', 'apple-touch-icon.png'],
       manifest: {
         name: 'KA Mensa',
+        short_name: 'KA Mensa',
         description: 'Mensaplan für Karlsruhe',
         lang: 'de',
         scope: '/',


### PR DESCRIPTION
The value defaulted to the package.json name, which is 'ka-mensa-ui',
instead of the intended 'KA Mensa'. This patch sets the short name
explicitly to prevent that.