### PR TITLE
chore: Avoid duplicating page metadata in HTML and manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,9 @@
 <!DOCTYPE html>
-<html lang="de">
+<html>
   <head>
     <meta charset="utf-8">
-    <title>KA Mensa</title>
+    <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Mensaplan für Karlsruhe">
-    <link rel="icon" href="/favicon.ico" sizes="16x16">
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180">
-    <meta name="theme-color" content="#5f9e40">
   </head>
   <body>
     <div id="app"></div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,76 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type PluginOption } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { VitePWA } from 'vite-plugin-pwa'
+
+/**
+ * Page information for the meta inject plugin.
+ */
+interface PageMeta {
+  name: string
+  lang: string
+  favicon: string
+  apple_touch_icon: string
+  description: string
+  theme_color: string
+}
+
+/**
+ * Factory for a Vite plugin that injects PWA manifest options into the page as meta tags.
+ *
+ * @param manifest The page metadata.
+ * @returns The plugin.
+ */
+function injectPageMeta (manifest: PageMeta): PluginOption {
+  return {
+    name: 'inject-manifest-meta',
+    transformIndexHtml: (html) => ({
+      html: html
+        .replace(/<html>/, `<html lang="${manifest.lang}">`)
+        .replace(/<title>(.*?)<\/title>/, `<title>${manifest.name}</title>`),
+      tags: [
+        {
+          tag: 'link',
+          attrs: { rel: 'icon', href: manifest.favicon },
+          injectTo: 'head'
+        },
+        {
+          tag: 'link',
+          attrs: { rel: 'apple-touch-icon', href: manifest.apple_touch_icon, sizes: '180x180' },
+          injectTo: 'head'
+        },
+        {
+          tag: 'meta',
+          attrs: { name: 'description', value: manifest.description },
+          injectTo: 'head'
+        },
+        {
+          tag: 'meta',
+          attrs: { name: 'theme-color', value: manifest.theme_color },
+          injectTo: 'head'
+        }
+      ]
+    })
+  }
+}
+
+const manifest = {
+  name: 'KA Mensa',
+  short_name: 'KA Mensa',
+  description: 'Mensaplan für Karlsruhe',
+  lang: 'de',
+  scope: '/',
+  start_url: '/?source=pwa',
+  display: 'standalone' as const,
+  orientation: 'portrait' as const,
+  icons: [192, 512, 1024].map((size) => ({
+    src: `icon-${size}.png`,
+    sizes: `${size}x${size}`,
+    type: 'image/png',
+    purpose: 'any maskable'
+  })),
+  background_color: '#dedddc',
+  theme_color: '#5f9e40'
+}
 
 export default defineConfig({
   plugins: [
@@ -9,38 +79,12 @@ export default defineConfig({
       manifestFilename: 'manifest.json',
       registerType: 'autoUpdate',
       includeAssets: ['favicon.ico', 'robots.txt', 'apple-touch-icon.png'],
-      manifest: {
-        name: 'KA Mensa',
-        short_name: 'KA Mensa',
-        description: 'Mensaplan für Karlsruhe',
-        lang: 'de',
-        scope: '/',
-        start_url: '/?source=pwa',
-        display: 'standalone',
-        orientation: 'portrait',
-        icons: [
-          {
-            src: 'icon-192.png',
-            sizes: '192x192',
-            type: 'image/png',
-            purpose: 'any maskable'
-          },
-          {
-            src: 'icon-512.png',
-            sizes: '512x512',
-            type: 'image/png',
-            purpose: 'any maskable'
-          },
-          {
-            src: 'icon-1024.png',
-            sizes: '1024x1024',
-            type: 'image/png',
-            purpose: 'any maskable'
-          }
-        ],
-        background_color: '#dedddc',
-        theme_color: '#5f9e40'
-      }
+      manifest
+    }),
+    injectPageMeta({
+      ...manifest,
+      favicon: 'favicon.ico',
+      apple_touch_icon: 'apple-touch-icon.png'
     })
   ]
 })


### PR DESCRIPTION
This patch adds a custom Vite plugin to the config. The plugin takes the
PWA manifest definition (and a bit extra) as input, and generates the
appropriate link and meta tags from that. These things can then be
removed from the HTML. Hence, there is only a single place where they
are defined instead of redundancy that could get out of sync.