### PR TITLE
fix: Use `@fontsource/nunito` instead of `typeface-nunito`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@fontsource/nunito": "4.5.12",
         "events": "3.3.0",
         "moment": "2.29.4",
-        "typeface-nunito": "1.1.13",
         "vue": "3.2.47"
       },
       "devDependencies": {
@@ -2279,6 +2279,11 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@fontsource/nunito": {
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/@fontsource/nunito/-/nunito-4.5.12.tgz",
+      "integrity": "sha512-Li90TCJha1E+nBgP51GjcIGV6LxyQi7QisW8KZ4kpz5mpnQc1HmsJWVr9fyTMItUF/OuZUOfEazenXjaY6qRpQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -7358,11 +7363,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/typeface-nunito": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/typeface-nunito/-/typeface-nunito-1.1.13.tgz",
-      "integrity": "sha512-S7tN6pMnJapUxRDNa/RPXtcsxJC0KkBNPFOfGpHCkatVLm+6ltMedgeGtr1lPZsGFXGN890TZmE18bq2pdsmKw=="
     },
     "node_modules/typescript": {
       "version": "4.9.5",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "homepage": "https://github.com/meyfa/ka-mensa-ui",
   "dependencies": {
+    "@fontsource/nunito": "4.5.12",
     "events": "3.3.0",
     "moment": "2.29.4",
-    "typeface-nunito": "1.1.13",
     "vue": "3.2.47"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,8 @@
 <script lang="ts">
 import { defineComponent, onMounted, onUnmounted, ref } from 'vue'
 
-import 'typeface-nunito'
+import '@fontsource/nunito/400.css'
+import '@fontsource/nunito/700.css'
 
 import type { DateSpec } from './types/date-spec.js'
 import settings from './settings.js'


### PR DESCRIPTION
The Typefaces project is deprecated and should be replaced by Fontsource packages. In practice, this fixes a font-weight bug in Chrome and Chromium-based browsers.