### PR TITLE
fix: Set type to "module" to let Vite build in ESM mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "ka-mensa-ui",
   "version": "0.0.0",
   "description": "Karlsruhe (KIT) Mensa meal plan UI for use with ka-mensa-api",
+  "type": "module",
   "scripts": {
     "build": "vite build",
     "lint": "tsc --noEmit -p tsconfig.lint.json && eslint --ignore-path .gitignore --ext .ts,.js,.vue ./src && stylelint \"./src/**/*.{css,vue}\"",


### PR DESCRIPTION
Up until now the project ran in CommonJS mode, which is now deprecated by Vite v5:

> The CJS build of Vite's Node API is deprecated. See
> https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated
> for more details.

Set the type to "module" to fix this.